### PR TITLE
Add reference_frame_id and templates

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,30 @@
+### Configuration
+
+- Operating system: \<Ubuntu> <Version> LTS\>
+
+- Package version: \<0.1.0\>
+
+### Description of problem
+
+- \<Currently it is possible to build ...\>
+
+### Steps to Reproduce
+
+1. step
+2. step
+
+### Actual Results
+
+- \<API internal error\>
+
+### Expected Results
+
+- \<Successful build\>
+
+### Related Package/PR
+
+- N/A.
+
+### Notes
+
+- N/A.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,47 @@
+#### **Overview**
+
+- \<Overview for request or description for added feature.\>
+- \<This section should contain a brief description of the requested resource.\>
+- \<Briefly describe the feature. Images can be included to improve the understanding of the functionality.\>
+
+#### **Use the following settings in the overrides file for docker testing**
+
+- Use these settings to compile and run the module using `autoproj`.
+- The contents of the files manifest and `overrides.yaml` must be changed according to the `templates` below.
+- Additional packages may be needed to test this module.
+
+  e.g.,
+
+- _overrides.yaml_
+
+  ```yaml
+    overrides:
+      - <package>:
+        branch: <branch>
+  ```
+
+- _manifest_
+
+  ```yaml
+    package_sets:
+      - github: Brazilian-Institute-of-Robotics/bir.subot-package_set
+        private: true
+    layout:
+      - <package>
+  ```
+
+#### **What was added/changed in this update**
+
+- \<Use the commit messages to describe what was included.\>
+
+#### **Depends On:**
+
+- \<Inform if there is a dependency on other pull requests.\>
+
+#### **Related Issues:**
+
+- \<Inform if the pull request is associated with issues.\>
+
+#### **Notes:**
+
+- Include notes and notes specific to this pull request here, if not, include the expression N/A. (Not Applicable)

--- a/param/xsens_mti_node.yaml
+++ b/param/xsens_mti_node.yaml
@@ -23,6 +23,7 @@
 
         # TF transform frame_id (default: imu_link), you may want to change it if you use multiple devices
         frame_id: "imu_link"
+        reference_frame_id: "world"
 
         # Message publishers
         pub_imu: true

--- a/src/messagepublishers/packetcallback.h
+++ b/src/messagepublishers/packetcallback.h
@@ -66,6 +66,7 @@
 #include <xstypes/xsdatapacket.h>
 
 const char* DEFAULT_FRAME_ID = "imu_link";
+const char* DEFAULT_REFERENCE_FRAME_ID = "world";
 
 class PacketCallback
 {

--- a/src/messagepublishers/transformpublisher.h
+++ b/src/messagepublishers/transformpublisher.h
@@ -70,10 +70,12 @@ struct TransformPublisher : public PacketCallback
 {
     tf2_ros::TransformBroadcaster tf_broadcaster;
     std::string frame_id = DEFAULT_FRAME_ID;
+    std::string reference_frame_id = DEFAULT_REFERENCE_FRAME_ID;
 
     TransformPublisher(rclcpp::Node &node) : tf_broadcaster(node)
     {
         node.get_parameter("frame_id", frame_id);
+        node.get_parameter("reference_frame_id", reference_frame_id);
     }
 
     void operator()(const XsDataPacket &packet, rclcpp::Time timestamp)
@@ -85,7 +87,7 @@ struct TransformPublisher : public PacketCallback
             XsQuaternion q = packet.orientationQuaternion();
 
             tf.header.stamp = timestamp;
-            tf.header.frame_id = "world";
+            tf.header.frame_id = reference_frame_id;
             tf.child_frame_id = frame_id;
             tf.transform.translation.x = 0.0;
             tf.transform.translation.y = 0.0;

--- a/src/xdainterface.cpp
+++ b/src/xdainterface.cpp
@@ -332,6 +332,9 @@ void XdaInterface::declareCommonParameters()
 	std::string frame_id = DEFAULT_FRAME_ID;
 	declare_parameter("frame_id", frame_id);
 
+	std::string reference_frame_id = DEFAULT_REFERENCE_FRAME_ID;
+	declare_parameter("reference_frame_id", reference_frame_id);
+
 	int pub_queue_size = 5;
 	declare_parameter("publisher_queue_size", pub_queue_size);
 


### PR DESCRIPTION
### Overview

This PR adds the templates, both for future Issues and PRs. It also adds a reference frame ID to attach the IMU frame.

#### **Use the following settings in the overrides file for docker testing**

- N/A

### What was added/changed in this update

- [Add reference_frame_id dynamic configuration](https://github.com/Brazilian-Institute-of-Robotics/bluespace_ai_xsens_ros_mti_driver/commit/5508253949e2de862bab880a980016fe80d47bc5)
- [Add Issue and PR templates](https://github.com/Brazilian-Institute-of-Robotics/bluespace_ai_xsens_ros_mti_driver/commit/e848a5da355793e7f4d0d6c3bbfa0766ce34a1e5)

### Depends On:

This PR has no dependencies on other PR.

### Related Issues:

This PR is not related to any issue.

### Notes:

N/A.