### PR TITLE
Add MGBE action

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,11 +11,20 @@ endif()
 # Find dependencies
 find_package(ament_cmake REQUIRED)
 find_package(rclcpp REQUIRED)
+find_package(rclcpp_action REQUIRED)
 find_package(tf2 REQUIRED)
 find_package(tf2_ros REQUIRED)
 find_package(std_msgs REQUIRED)
 find_package(geometry_msgs REQUIRED)
 find_package(sensor_msgs REQUIRED)
+find_package(rosidl_default_generators REQUIRED)
+
+rosidl_generate_interfaces(${PROJECT_NAME}
+  "action/SetNoRotation.action"
+  DEPENDENCIES std_msgs
+)
+
+ament_export_dependencies(rosidl_default_runtime)
 
 ###########
 ## Build ##
@@ -35,11 +44,16 @@ target_include_directories(xsens_mti_node PUBLIC
 
 ament_target_dependencies(xsens_mti_node 
   rclcpp
+  rclcpp_action
   tf2
   tf2_ros
   std_msgs
   geometry_msgs
   sensor_msgs
+)
+
+rosidl_target_interfaces(xsens_mti_node
+  ${PROJECT_NAME} "rosidl_typesupport_cpp"
 )
 
 target_link_libraries(

--- a/action/SetNoRotation.action
+++ b/action/SetNoRotation.action
@@ -1,0 +1,4 @@
+uint16 seconds
+---
+bool result
+---

--- a/package.xml
+++ b/package.xml
@@ -8,20 +8,28 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
   <buildtool_depend>rclcpp</buildtool_depend>
+  <buildtool_depend>rclcpp_action</buildtool_depend>
 
+  <build_depend>rosidl_default_generators</build_depend>
   <build_depend>rclcpp</build_depend>
+  <build_depend>rclcpp_action</build_depend>
   <build_depend>tf2</build_depend>
   <build_depend>tf2_ros</build_depend>
   <build_depend>std_msgs</build_depend>
   <build_depend>geometry_msgs</build_depend>
   <build_depend>sensor_msgs</build_depend>
+
   <build_export_depend>rclcpp</build_export_depend>
+  <build_export_depend>rclcpp_action</build_export_depend>
   <build_export_depend>tf2</build_export_depend>
   <build_export_depend>tf2_ros</build_export_depend>
   <build_export_depend>std_msgs</build_export_depend>
   <build_export_depend>geometry_msgs</build_export_depend>
   <build_export_depend>sensor_msgs</build_export_depend>
+  <exec_depend>rosidl_default_runtime</exec_depend>
+
   <exec_depend>rclcpp</exec_depend>
+  <exec_depend>rclcpp_action</exec_depend>
   <exec_depend>tf2</exec_depend>
   <exec_depend>tf2_ros</exec_depend>
   <exec_depend>std_msgs</exec_depend>
@@ -29,6 +37,9 @@
   <exec_depend>sensor_msgs</exec_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
+
+  <member_of_group>rosidl_interface_packages</member_of_group>
+
   <export>
     <build_type>ament_cmake</build_type>
   </export>

--- a/src/xdainterface.h
+++ b/src/xdainterface.h
@@ -63,8 +63,10 @@
 #define XDAINTERFACE_H
 
 #include <rclcpp/rclcpp.hpp>
+#include <rclcpp_action/rclcpp_action.hpp>
 
 #include "xdacallback.h"
+#include "bluespace_ai_xsens_mti_driver/action/set_no_rotation.hpp"
 #include <xstypes/xsportinfo.h>
 
 #include "chrono"
@@ -95,11 +97,22 @@ private:
 	bool handleError(std::string error);
 	void declareCommonParameters();
 
+	void executeMgbe(
+		const std::shared_ptr<rclcpp_action::ServerGoalHandle<
+		bluespace_ai_xsens_mti_driver::action::SetNoRotation>>
+		goal_handle);
+
+	bool perform_mgbe(uint16_t duration);
+
 	XsControl *m_control;
 	XsDevice *m_device;
 	XsPortInfo m_port;
 	XdaCallback m_xdaCallback;
 	std::list<PacketCallback *> m_callbacks;
+	uint32_t status_word = 0;
+	std::mutex mutex;
+	rclcpp_action::Server<
+		bluespace_ai_xsens_mti_driver::action::SetNoRotation>::SharedPtr mgbe_server;
 };
 
 #endif


### PR DESCRIPTION
#### **Overview**

This PR adds the Manual Gyro Bias Estimation functionality to the MTi driver. This estimation is performed automatically during driver initialization, but a ros2 action is also available.

#### **Use the following settings in the overrides file for docker testing**

Before compiling the pkg, run:

```sh
$    acd
$    pushd src/bluespace_ai_xsens_mti_driver/lib/xspublic && make && popd
```

- _overrides.yaml_

  ```yaml
    overrides:
      - bluespace_ai_xsens_mti_driver:
        branch: add/mgbe_action
  ```

- _manifest_

  ```yaml
    layout:
      - bluespace_ai_xsens_mti_driver
  ```

#### **What was added/changed in this update**

[Add MGBE action](https://github.com/Brazilian-Institute-of-Robotics/bluespace_ai_xsens_mti_driver/commit/35a77fda10ff78e79f290f41ee103cad3e26a02a)

#### **Depends On:**

#### **Related Issues:**

#### **Notes:**

N/A.